### PR TITLE
Update q.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: node_js
 node_js:
   - "0.10"
 script:
-  npm run lint && npm test
+  npm test

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "promises-aplus-tests": "1.x"
   },
   "scripts": {
-    "test": "jasmine-node spec && promises-aplus-tests spec/aplus-adapter",
+    "test": "npm ls -s && jasmine-node spec && promises-aplus-tests spec/aplus-adapter && npm run -s lint",
     "test-browser": "opener spec/q-spec.html",
     "benchmark": "matcha",
     "lint": "jshint q.js",

--- a/q.js
+++ b/q.js
@@ -725,7 +725,7 @@ Promise.prototype.join = function (that) {
             // TODO: "===" should be Object.is or equiv
             return x;
         } else {
-            throw new Error("Can't join: not the same: " + x + " " + y);
+            throw new Error("Q can't join: not the same: " + x + " " + y);
         }
     });
 };
@@ -1626,7 +1626,7 @@ function any(promises) {
             pendingCount--;
             if (pendingCount === 0) {
                 deferred.reject(new Error(
-                    "Can't get fulfillment value from any promise, all " +
+                    "Q can't get fulfillment value from any promise, all " +
                     "promises were rejected."
                 ));
             }
@@ -1753,7 +1753,7 @@ Q["finally"] = function (object, callback) {
 Promise.prototype.fin = // XXX legacy
 Promise.prototype["finally"] = function (callback) {
     if (!callback || typeof callback.apply !== "function") {
-        throw new Error("Can't apply finally callback");
+        throw new Error("Q can't apply finally callback");
     }
     callback = Q(callback);
     return this.then(function (value) {
@@ -1919,7 +1919,7 @@ Promise.prototype.nfcall = function (/*...args*/) {
 Q.nfbind =
 Q.denodeify = function (callback /*...args*/) {
     if (callback === undefined) {
-        throw new Error('Q Cannot wrap an undefined function');
+        throw new Error("Q can't wrap an undefined function");
     }
     var baseArgs = array_slice(arguments, 1);
     return function () {

--- a/spec/q-spec.js
+++ b/spec/q-spec.js
@@ -1218,7 +1218,7 @@ describe("any", function() {
           .then(function() {
               expect(promise.isRejected()).toBe(true);
               expect(promise.inspect().reason.message)
-              .toBe("Can't get fulfillment value from any promise, all promises were rejected.");
+              .toBe("Q can't get fulfillment value from any promise, all promises were rejected.");
           })
           .timeout(1000);
     }
@@ -1680,7 +1680,7 @@ describe("fin", function () {
                 try {
                     Q().fin(foo.bar);
                 } catch (err) {
-                    expect(err.message).toBe("Can't apply finally callback");
+                    expect(err.message).toBe("Q can't apply finally callback");
                     threw = true;
                 }
 
@@ -1695,7 +1695,7 @@ describe("fin", function () {
                 try {
                     Q().fin(123);
                 } catch (err) {
-                    expect(err.message).toBe("Can't apply finally callback");
+                    expect(err.message).toBe("Q can't apply finally callback");
                     threw = true;
                 }
 


### PR DESCRIPTION
nfbind/denodeify: Throw error when wrapping an undefined function. Leads to clearer error message/stack (instead of throwing error when using the resulting promised wrapped function.

Next step: I have the feeling this fix could also be applied to Q.nbind (https://github.com/kriskowal/q/blob/v1/q.js#L1938). I'll do it if this PR is accepted.
